### PR TITLE
'[!code-csharp' need line head.

### DIFF
--- a/aspnetcore/includes/RP/model2.md
+++ b/aspnetcore/includes/RP/model2.md
@@ -7,6 +7,7 @@
 <a name="dc"></a>
 ### <a name="add-a-database-context-class"></a>データベース コンテキスト クラスの追加
 
-*MovieContext.cs* という次の `DbContext` 派生クラスを *Models* フォルダーに追加します。[!code-csharp[Main](../../tutorials/razor-pages/razor-pages-start/snapshot_sample/RazorPagesMovie/Models/MovieContext.cs)]
+*MovieContext.cs* という次の `DbContext` 派生クラスを *Models* フォルダーに追加します。
+[!code-csharp[Main](../../tutorials/razor-pages/razor-pages-start/snapshot_sample/RazorPagesMovie/Models/MovieContext.cs)]
 
 上記のコードによって、エンティティ セットの `DbSet` プロパティが作成されます。 Entity Framework の用語では、エンティティ セットは通常はデータベース テーブルに対応し、エンティティはテーブルの行に対応します。


### PR DESCRIPTION
this file is used 'https://github.com/aspnet/docs.ja-jp/blob/live/aspnetcore/tutorials/razor-pages/model.md'.

currently, official site doesn't show source code snippet at 'https://docs.microsoft.com/ja-jp/aspnet/core/tutorials/razor-pages/model'. following image.
![4](https://user-images.githubusercontent.com/25697841/39297526-b6ef6b1e-497e-11e8-97c8-50310a7f5d33.png)

I cloned aspnet/Docs and aspnet/Docs.ja-jp. and tested by docfx.

![5](https://user-images.githubusercontent.com/25697841/39297863-9808a1f6-497f-11e8-971c-cdc086fb1dda.png)

