### PR TITLE
表現の修正

### DIFF
--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -38,7 +38,7 @@ Razor ページと Entity Framework が提供している検証のサポート�
 
 検証属性で、モデルのプロパティに適用されている動作を指定します。
 
-* `Required` と `MinimumLength` の属性は、プロパティに値が必要なことを示します。 ただし、ユーザーが空白を入力することで null 許容型の妥当性制約を満たすことはできます。 null 非許容の[値の型](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/value-types) (`decimal`、`int`、`float`、`DateTime` など) は本質的に必須ではなく、`Required` 属性を必要としません。
+* `Required` と `MinimumLength` の属性は、プロパティに値が必要なことを示します。 ただし、ユーザーがnull 許容型の妥当性制約を満たすために空白を入力することを防ぐことはできません。 null 非許容の[値の型](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/value-types) (`decimal`、`int`、`float`、`DateTime` など) は本質的に必須ではなく、`Required` 属性を必要としません。
 * `RegularExpression` 属性は、ユーザーが入力できる文字を制限します。 上記のコードで、`Genre` と `Rating` は、文字のみを使用する必要があります (空白、数字、特殊文字は使用できません)。
 * `Range` 属性は、指定した範囲に値を制限します。
 * `StringLength` 属性は文字列の最大長を設定します。必要に応じて、最短長も設定できます。 


### PR DESCRIPTION
原文は、"However, nothing prevents a user from entering whitespace to satisfy the validation constraint for a nullable type."であり、空白の入力によるnullチェックの回避を防ぐことはできない、という否定的な意味合いの文です。よって、明確な誤訳ではありませんが、肯定的な表現は原文の意図からは乖離しており、誤解を招きます。
誤「ただし、ユーザーが空白を入力することで null 許容型の妥当性制約を満たすことはできます。」
正「ただし、ユーザーがnull 許容型の妥当性制約を満たすために空白を入力することを防ぐことはできません。」