### PR TITLE
Update the razor.md.

### DIFF
--- a/aspnet/includes/razor.md
+++ b/aspnet/includes/razor.md
@@ -1,7 +1,7 @@
-このチュートリアルの更新バージョンが利用可能な[ここ](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app/start-mvc)の最新バージョンを使用して[Visual Studio。](https://www.visualstudio.com) 新しいチュートリアルでは使用[ASP.NET Core MVC](https://docs.microsoft.com/aspnet/core/mvc/)、提供する**多く**このチュートリアルからの改善点です。
+このチュートリアルの最新バージョンは、最新の [Visual Studio](https://www.visualstudio.com) を利用して[ここ](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app/start-mvc)から入手できます。新しいチュートリアルは [ASP.NET Core MVC](https://docs.microsoft.com/aspnet/core/mvc/) を使用しており、このチュートリアルよりも**多くの**改善点が含まれています。
 
 このチュートリアルでは、ASP.NET Core MVC のコントローラーとビューについて説明します。 ASP.NET Core 2.0 の新しい代替である Razor ページはページ ベースのプログラミング モデルであり、Web UI の開発を容易にし、生産性を高めます。 MVC のバージョンの前に、[Razor ページ](https://docs.microsoft.com/aspnet/core/mvc/razor-pages)のチュートリアルを試すことをお勧めします。 この Razor ページのチュートリアルの特徴は次のとおりです。
 
-* 使いやすい。
+* 理解しやすい。
 * 多くの機能をカバーしている。
 * 新しいアプリケーションの開発で推奨されるアプローチである。


### PR DESCRIPTION
The japanese syntax which contains the link of other location is little odd.

1)  An updated version of this tutorial is available [here](https://docs.microsoft.com/aspnet/core/tutorials/first-mvc-app/start-mvc) using the latest version of [Visual Studio.](https://www.visualstudio.com)
  This sentence is translated 「このチュートリアルの更新バージョンが利用可能なここの最新バージョンを使用してVisual Studio。」.
  This mean that "An updated version of this tutorial is available here using the latest version of Visual Studio.". 
  Perhaps, I think that automation translation couldn't distinguish the end of a sentence.

2) The new tutorial uses [ASP.NET Core MVC](https://docs.microsoft.com/aspnet/core/mvc/), which provides **many** improvements over this tutorial.
   This is same to 1) comment.

3) Is easier to follow. 
  This is translated as "Is easier to use" in this japanese sentence. I think this mean is closer to "Is easier to understand" in this context.