### PR TITLE
Fix  translated introduction page.

### DIFF
--- a/aspnet/web-api/videos/getting-started/aspnet-web-api.md
+++ b/aspnet/web-api/videos/getting-started/aspnet-web-api.md
@@ -17,6 +17,6 @@ ms.locfileid: "41833397"
 ---
 <a name="aspnet-web-api"></a>ASP.NET Web API
 ====================
-によって[Scott Hanselman](https://github.com/shanselman)
+[Scott Hanselman](https://github.com/shanselman)による
 
 [&#9654;ビデオ (6 分)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/aspnet-web-api)

--- a/aspnet/web-api/videos/getting-started/authorization.md
+++ b/aspnet/web-api/videos/getting-started/authorization.md
@@ -17,7 +17,7 @@ ms.locfileid: "41827431"
 ---
 <a name="aspnet-web-api-part-6-authorization"></a>ASP.NET Web API、パート 6: 承認
 ====================
-によって[Jon Galloway](https://github.com/jongalloway)
+[Jon Galloway](https://github.com/jongalloway) による
 
 > [!NOTE]
 > このビデオには、ASP.NET Web API のリリース前のバージョンからの情報が含まれています。 変更点についてで更新済みサンプル コードを参照してください。 [https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7](https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7)

--- a/aspnet/web-api/videos/getting-started/custom-validation.md
+++ b/aspnet/web-api/videos/getting-started/custom-validation.md
@@ -17,7 +17,7 @@ ms.locfileid: "41831508"
 ---
 <a name="aspnet-web-api-part-5-custom-validation"></a>カスタム検証を ASP.NET Web API、パート 5 です。
 ====================
-によって[Jon Galloway](https://github.com/jongalloway)
+[Jon Galloway](https://github.com/jongalloway) による
 
 > [!NOTE]
 > このビデオには、ASP.NET Web API のリリース前のバージョンからの情報が含まれています。 変更点についてで更新済みサンプル コードを参照してください。 [https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7](https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7)

--- a/aspnet/web-api/videos/getting-started/delete-and-update.md
+++ b/aspnet/web-api/videos/getting-started/delete-and-update.md
@@ -17,7 +17,7 @@ ms.locfileid: "41835366"
 ---
 <a name="aspnet-web-api-part-3-delete-and-update"></a>ASP.NET Web API、パート 3: 削除および更新
 ====================
-によって[Jon Galloway](https://github.com/jongalloway)
+[Jon Galloway](https://github.com/jongalloway) による
 
 > [!NOTE]
 > このビデオには、ASP.NET Web API のリリース前のバージョンからの情報が含まれています。 変更点についてで更新済みサンプル コードを参照してください。 [https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7](https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7)

--- a/aspnet/web-api/videos/getting-started/getting-data.md
+++ b/aspnet/web-api/videos/getting-started/getting-data.md
@@ -17,7 +17,7 @@ ms.locfileid: "41827902"
 ---
 <a name="aspnet-web-api-part-2-getting-data"></a>ASP.NET Web API、パート 2: データの取得
 ====================
-によって[Jon Galloway](https://github.com/jongalloway)
+[Jon Galloway](https://github.com/jongalloway) による
 
 > [!NOTE]
 > このビデオには、ASP.NET Web API のリリース前のバージョンからの情報が含まれています。 変更点についてで更新済みサンプル コードを参照してください。 [https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7](https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7)

--- a/aspnet/web-api/videos/getting-started/index.md
+++ b/aspnet/web-api/videos/getting-started/index.md
@@ -26,8 +26,8 @@ ms.locfileid: "26508991"
 
 - [ASP.NET Web API](aspnet-web-api.md)
 - [ASP.NET Web API、パート 1: 最初 Web API](your-first-web-api.md)
-- [ASP.NET Web API、第 2 部: データの取得](getting-data.md)
+- [ASP.NET Web API、パート 2: データの取得](getting-data.md)
 - [ASP.NET Web API、パート 3: 削除および更新](delete-and-update.md)
-- [ページングと、クエリを実行する ASP.NET Web API、パート 4:](paging-and-querying.md)
+- [ASP.NET Web API、パート 4: ページングと、クエリを実行する](paging-and-querying.md)
 - [ASP.NET Web API、パート 5: カスタム検証](custom-validation.md)
 - [ASP.NET Web API、パート 6: 承認](authorization.md)

--- a/aspnet/web-api/videos/getting-started/paging-and-querying.md
+++ b/aspnet/web-api/videos/getting-started/paging-and-querying.md
@@ -17,7 +17,7 @@ ms.locfileid: "41833552"
 ---
 <a name="aspnet-web-api-part-4-paging-and-querying"></a>ASP.NET Web API、パート 4: ページングとクエリを実行します。
 ====================
-によって[Jon Galloway](https://github.com/jongalloway)
+[Jon Galloway](https://github.com/jongalloway) による
 
 > [!NOTE]
 > このビデオには、ASP.NET Web API のリリース前のバージョンからの情報が含まれています。 変更点についてで更新済みサンプル コードを参照してください。 [https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7](https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7)

--- a/aspnet/web-api/videos/getting-started/your-first-web-api.md
+++ b/aspnet/web-api/videos/getting-started/your-first-web-api.md
@@ -17,7 +17,7 @@ ms.locfileid: "41836749"
 ---
 <a name="aspnet-web-api-part-1-your-first-web-api"></a>ASP.NET Web API、パート 1 です。 Web API の入門
 ====================
-によって[Jon Galloway](https://github.com/jongalloway)
+[Jon Galloway](https://github.com/jongalloway) による
 
 > [!NOTE]
 > このビデオには、ASP.NET Web API のリリース前のバージョンからの情報が含まれています。 変更点についてで更新済みサンプル コードを参照してください。 [https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7](https://code.msdn.microsoft.com/ASPNET-Web-API-JavaScript-d0d64dd7)


### PR DESCRIPTION
This PR caontains:

 * Fix  translated introduction word of video auther.
    The "by [name]" is translated as 「によって [name]」. The 「によって」 modify the next word by the before word.  i.e., [name] should be mention before 「によって」 word.

 * Fix video list title for consistency. 