### PR TITLE
Update the explain sentence of CDN location.

### DIFF
--- a/aspnet/ajax/cdn/cdnajax4.md
+++ b/aspnet/ajax/cdn/cdnajax4.md
@@ -56,6 +56,6 @@ ms.locfileid: "41829250"
 - https://ajax.aspnetcdn.com/ajax/4.0/1/WebParts.js
 - https://ajax.aspnetcdn.com/ajax/4.0/1/WebUIValidation.js
 
-注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されたことができます。
+注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されています。
 
 - https://ajax.aspnetcdn.com/ajax/4.0/1/globalization/

--- a/aspnet/ajax/cdn/cdnajax451.md
+++ b/aspnet/ajax/cdn/cdnajax451.md
@@ -56,6 +56,6 @@ ms.locfileid: "41836810"
 - https://ajax.aspnetcdn.com/ajax/4.5.1/1/WebParts.js
 - https://ajax.aspnetcdn.com/ajax/4.5.1/1/WebUIValidation.js
 
-注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されたています。
+注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されています。
 
 - https://ajax.aspnetcdn.com/ajax/4.5.1/1/globalization/

--- a/aspnet/ajax/cdn/cdnajax451.md
+++ b/aspnet/ajax/cdn/cdnajax451.md
@@ -56,6 +56,6 @@ ms.locfileid: "41836810"
 - https://ajax.aspnetcdn.com/ajax/4.5.1/1/WebParts.js
 - https://ajax.aspnetcdn.com/ajax/4.5.1/1/WebUIValidation.js
 
-注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されたことができます。
+注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されたています。
 
 - https://ajax.aspnetcdn.com/ajax/4.5.1/1/globalization/

--- a/aspnet/ajax/cdn/cdnajax452.md
+++ b/aspnet/ajax/cdn/cdnajax452.md
@@ -56,6 +56,6 @@ ms.locfileid: "41823832"
 - https://ajax.aspnetcdn.com/ajax/4.5.2/1/WebParts.js
 - https://ajax.aspnetcdn.com/ajax/4.5.2/1/WebUIValidation.js
 
-注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されたことができます。
+注: fr-FR.js など、グローバリゼーション スクリプトは、次のフォルダーに格納されています。
 
 - https://ajax.aspnetcdn.com/ajax/4.5.2/1/globalization/


### PR DESCRIPTION
"can be found in the following folder" translated as 「次のフォルダーに格納されたことができます」.
「されたことができます」is "You can do to be done". Usually, Japanese doesn't use this word usually.

In this case, we need to use 「次のフォルダーに格納されています」